### PR TITLE
ansible 2.4 prep, include to include_tasks

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 # tasks file for ansible-role-idmapd
 
-- include: redhat.yml
+- include_tasks: redhat.yml
   when: idmapd_enabled and ansible_os_family == "RedHat"
 


### PR DESCRIPTION
Ansible 2.4 warns that include is deprecated. Change it to include_tasks instead.
